### PR TITLE
add fix_mapToGlobal_can_crash.patch (upstream fix of QTBUG-67024)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtdeclarative-opensource-src (5.9.5-0ubports3) xenial; urgency=medium
+
+  * add fix for QTBUG-67024 which was fixed upstream in 5.9.6 and 5.11.1 (fixes segfault of QtWebEngine 5.13)
+
+ -- Chris Clime <chris.clime@gmx.net> Sun, 19 Jun 2020 12:59:00 +0100
+
 qtdeclarative-opensource-src (5.9.5-0ubports2) xenial; urgency=medium
 
   * Update Jenkinsfile as of ubports/build-tools@0af3831

--- a/debian/patches/fix_mapToGlobal_can_crash.patch
+++ b/debian/patches/fix_mapToGlobal_can_crash.patch
@@ -1,0 +1,27 @@
+Description: apply bugfix for crash on transforms (was fixed upstream in Qt 5.9.6 and 5.11.1)
+Author: Chris Clime <chris.clime@gmx.net>
+Bug: https://bugreports.qt.io/browse/QTBUG-67024
+
+--- a/src/quick/items/qquickitem.cpp
++++ b/src/quick/items/qquickitem.cpp
+@@ -3121,6 +3121,9 @@
+ */
+ QTransform QQuickItemPrivate::windowToGlobalTransform() const
+ {
++    if (Q_UNLIKELY(window == nullptr))
++        return QTransform();
++
+     QPoint quickWidgetOffset;
+     QWindow *renderWindow = QQuickRenderControl::renderWindowFor(window, &quickWidgetOffset);
+     QPointF pos = (renderWindow ? renderWindow : window)->mapToGlobal(quickWidgetOffset);
+@@ -3132,6 +3135,9 @@
+ */
+ QTransform QQuickItemPrivate::globalToWindowTransform() const
+ {
++    if (Q_UNLIKELY(window == nullptr))
++        return QTransform();
++
+     QPoint quickWidgetOffset;
+     QWindow *renderWindow = QQuickRenderControl::renderWindowFor(window, &quickWidgetOffset);
+     QPointF pos = (renderWindow ? renderWindow : window)->mapToGlobal(quickWidgetOffset);
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,6 @@ Do-not-make-lack-of-SSE2-support-on-x86-32-fatal.patch
 disable_jit_on_mips.patch
 revert_singletons_change.patch
 testcase_array_iteration.patch
+
+# UBPorts
+fix_mapToGlobal_can_crash.patch


### PR DESCRIPTION
https://bugreports.qt.io/browse/QTBUG-67024, might be the reason for the QtWebEngine 5.13 segmentation fault